### PR TITLE
Add netron to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ timm==0.5.4
 torch==1.10.1
 torchvision==0.11.2
 tqdm==4.64.0
+netron


### PR DESCRIPTION
- Add `netron` to requirements.txt as the package has been removed from `nvidia-tao-byom`'s dependency